### PR TITLE
Updates doc pages with versions

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -5,34 +5,34 @@ permalink: /docs/
 toc: false
 ---
 
-## Latest, Stable
+## Current, Stable
 
-The latest stable documentation is located at [docs.pulpproject.org](https://docs.pulpproject.org)
-
-
-## Older, Stable
-
-Pulp 2.8: [docs.pulpproject.org/en/2.8/](https://docs.pulpproject.org/en/2.8/)
-
-Pulp 2.7: [docs.pulpproject.org/en/2.7/](https://docs.pulpproject.org/en/2.7/)
-
-Pulp 2.6: [docs.pulpproject.org/en/2.6/](https://docs.pulpproject.org/en/2.6/)
+The latest stable documentation is located at [docs.pulpproject.org](http://docs.pulpproject.org)
 
 
 ## Release Candidate or Beta
 
-Pulp 2.9: [docs.pulpproject.org/en/2.9/testing/](https://docs.pulpproject.org/en/2.9/testing/)
-
-Pulp 2.8: [docs.pulpproject.org/en/2.8/testing/](https://docs.pulpproject.org/en/2.8/testing/)
+No release candidates or betas at this time.
 
 
 ## Nightly
 
-Pulp 2.10 nightly [docs.pulpproject.org/en/2.10/nightly/](https://docs.pulpproject.org/en/2.10/nightly/)
+Pulp 3.0 [docs.pulpproject.org/en/3.0/nightly/](http://docs.pulpproject.org/en/3.0/nightly/)
 
-Pulp 2.9 nightly [docs.pulpproject.org/en/2.9/nightly/](https://docs.pulpproject.org/en/2.9/nightly/)
+Pulp 2.11 [docs.pulpproject.org/en/2.11/nightly/](http://docs.pulpproject.org/en/2.11/nightly/)
+ 
+Pulp 2.10 [docs.pulpproject.org/en/2.10/nightly/](http://docs.pulpproject.org/en/2.10/nightly/)
 
-Pulp 2.8 nightly [docs.pulpproject.org/en/2.8/nightly/](https://docs.pulpproject.org/en/2.8/nightly/)
+
+## Older, Stable
+
+Pulp 2.9: [docs.pulpproject.org/en/2.9/](http://docs.pulpproject.org/en/2.9/)
+ 
+Pulp 2.8: [docs.pulpproject.org/en/2.8/](http://docs.pulpproject.org/en/2.8/)
+
+Pulp 2.7: [docs.pulpproject.org/en/2.7/](http://docs.pulpproject.org/en/2.7/)
+
+Pulp 2.6: [docs.pulpproject.org/en/2.6/](http://docs.pulpproject.org/en/2.6/)
 
 
 ## Related Projects


### PR DESCRIPTION
This updates the docs pages to match the current state
of Pulp. Also the links are now http instead of https
to avoid users experiencing the SSL certificate error
on docs.pulpproject.org.
