### PR TITLE
Problem: taglogic template renders incorrectly

### DIFF
--- a/_includes/taglogic.html
+++ b/_includes/taglogic.html
@@ -21,7 +21,7 @@
 
         <tr><td><a href="{{ post.url | prepend: site.baseurl }}">{{post.title}}</a></td>
             <td><span class="label label-primary">Post</span></td>
-            <td>{% if post.summary %} {{ post.summary | strip_html | strip_newlines | truncate: 160 }} {% else %} {{ post.content | truncatewords: 50 | strip_html }} {% endif %}</td>
+            <td>{% if post.summary %} {{ post.summary | strip_html | strip_newlines | truncate: 160 }} {% else %} {{ post.content | strip_html | truncatewords: 50 }} {% endif %}</td>
         </tr>
         {% endif %}
         {% endfor %}


### PR DESCRIPTION
Solution: In order to avoid removing HTML tags when truncating, the text is stripped
of HTML before the text is truncated.