### PR TITLE
Add homepage title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,8 @@ url: https://pulpproject.org/
 output: web
 # this property is useful for conditional filtering of content that is separate from the PDF.
 topnav_title: Pulp
+# this appears on homepage title before '|'
+homepage_title: Pulp
 # this appears on the top navigation bar next to the home button
 site_title: software repository management
 # this appears in the html browser tab for the site title (seen mostly by search engines, not users)

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class="post-header">
-   <h1 class="post-title-main">{% if page.homepage == true %} {{site.homepage_title}} {% else %}{{ page.title }}{% endif %}</h1>
+   <h1 class="post-title-main">{% if page.homepage != true %} {{ page.title }} {% endif %}</h1>
 </div>
 
 {% if page.map == true %}


### PR DESCRIPTION
Add missing homepage title on website pulpproject.org.

![pulp-missing-homepage-title](https://cloud.githubusercontent.com/assets/5434024/26037233/e438da84-390c-11e7-8b91-be956ec83198.png)

