### PR TITLE
Bump 'json' gem version to work on a recent Ruby (on F26)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       gemoji (~> 2.0)
       html-pipeline (~> 2.2)
       jekyll (>= 2.0)
-    json (1.8.3)
+    json (1.8.6)
     kramdown (1.9.0)
     liquid (3.0.6)
     listen (3.0.6)


### PR DESCRIPTION
The new builder on F26 needs this. It often happens the other way around but well…