### PR TITLE
Add blog post on pulp_python beta1 release announcement

### DIFF
--- a/_posts/2018-05-09-pulp_python-beta-release.md
+++ b/_posts/2018-05-09-pulp_python-beta-release.md
@@ -1,0 +1,33 @@
+---
+title: Pulp Python Plugin Beta 1 Release
+author: Bihan Zhang
+tags:
+  - release
+  - 3.0
+  - python
+---
+
+pulp_python 3.0 beta 1 has been released and can be [installed from PyPI](https://pypi.org/project/pulp-python/3.0.0b1/)
+
+## Features
+
+The pulp_python plugin supports the following features:
+
+- [Syncing](http://pulp-python.readthedocs.io/en/3.0.0b1/workflows/sync/) python projects from PyPI to Pulp
+- [Uploading](http://pulp-python.readthedocs.io/en/3.0.0b1/workflows/upload/) python packages (wheels, eggs, sdist) to Pulp
+- [Publishing and distributing](http://pulp-python.readthedocs.io/en/3.0.0b1/workflows/publish-host/) projects with PyPI's [simple API](https://wiki.python.org/moin/PyPISimple)
+- [Installing](http://pulp-python.readthedocs.io/en/3.0.0b1/workflows/publish-host/#use-the-newly-created-distribution) python packages from Pulp using pip
+
+## Documentation
+
+To find out how to install pulp_python or to read the docs around how to use pulp_python, check
+out [our docs](http://pulp-python.readthedocs.io/en/3.0.0b1/).
+
+## Getting involved
+
+To view our progress, report bugs, or request new features, check out our issue tracker at
+[https://pulp.plan.io/projects/pulp_python](https://pulp.plan.io/projects/pulp_python).
+
+## Demo
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/E7LrSP2VdIs?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>


### PR DESCRIPTION
Rendered page: https://werwty.github.io/pulpproject.org/2018/05/09/pulp_python-beta-release/