### PR TITLE
Fix missing favicon in Chrome

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,7 +24,7 @@
 <script src="{{ "/js/toc.js" | prepend: site.baseurl }}"></script>
 <script src="{{ "/js/customscripts.js" | prepend: site.baseurl }}"></script>
 
-<link rel="shortcut icon" href="http://docs.pulpproject.org/en/pulpproject.org_images/favicon.ico">
+<link rel="shortcut icon" href="https://docs.pulpproject.org/en/pulpproject.org_images/favicon.ico">
 
 <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->


### PR DESCRIPTION
Otherwise, this error occurs:
```
Mixed Content: The page at 'https://pulpproject.org/' was loaded over HTTPS, but requested an insecure favicon 'http://docs.pulpproject.org/en/pulpproject.org_images/favicon.ico'. This request has been blocked; the content must be served over HTTPS.
```