### PR TITLE
Rename ansible-pulp to pulp_installer

### DIFF
--- a/_posts/2019-05-29-travis-ci-cd-config-generator-for-pulp3-plugins.md
+++ b/_posts/2019-05-29-travis-ci-cd-config-generator-for-pulp3-plugins.md
@@ -15,7 +15,7 @@ created the Travis Config Generator.
 
 ### Continuous Integration (with every commit)
 
-* Install your plugin using the [Pulp Ansible Installer](https://github.com/pulp/ansible-pulp)
+* Install your plugin using the [Pulp 3 Ansible Installer](https://github.com/pulp/pulp_installer)
 * Run all functional and unit tests on a matrix including:
   * Python 3.6
   * Python 3.7

--- a/related-tooling.md
+++ b/related-tooling.md
@@ -17,7 +17,7 @@ Foreman and Katello are currently in the incremental [process of migrating from 
 
 ## Ansible Modules for Pulp aka Squeezer
 
-[This project](https://github.com/mdellweg/ansible_modules_pulp) provides ansible modules (currently only for pulp-file) to control a Pulp 3 server in a descriptive way. This is neither to be confused with ansible-pulp to install Pulp, nor pulp_ansible to manage ansible content in Pulp.
+[This project](https://github.com/mdellweg/ansible_modules_pulp) provides Ansible modules (currently only for pulp-file) to control a Pulp 3 server in a descriptive way. This is neither to be confused with the [Pulp 3 Ansible Installer pulp_installer](https://github.com/pulp/pulp_installer) (a collection of Ansible roles to install Pulp), nor [pulp_ansible](https://github.com/pulp/pulp_ansible) (a Pulp content plugin to manage Ansible content in Pulp.)
 
 ## pulp_rpm_repos
 


### PR DESCRIPTION
re: #6406
Rename ansible-pulp to pulp_installer
https://pulp.plan.io/issues/6406