### PR TITLE
Add About Pulp 3 page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,4 +238,4 @@ DEPENDENCIES
   nokogiri
 
 BUNDLED WITH
-   1.16.1
+   2.1.2

--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -12,8 +12,8 @@ entries:
       url: /
       output: web
       type: homepage
-    - title: Documentation
-      url: /docs/
+    - title: About Pulp 3
+      url: /about-pulp-3/
       output: web
     - title: Pulp 3 Plugins
       url: /pulp-3-plugins/

--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -5,8 +5,8 @@ topnav:
   items:
     - title: Home
       url: /
-    - title: Documentation
-      url: /docs/
+    - title: About Pulp 3
+      url: /about-pulp-3/
     - title: Pulp 3 Plugins
       url: /pulp-3-plugins/
     - title: Demo

--- a/about-pulp-3.md
+++ b/about-pulp-3.md
@@ -1,0 +1,47 @@
+---
+title: About Pulp 3
+sidebar: home_sidebar
+permalink: /about-pulp-3/
+toc: false
+---
+
+Pulp 3 builds on the achievements of Pulp 2, with a renewed focus on repository management. Pulp 3 is more than an update of Pulp 2. Pulp 3 is the result of years of feedback from Pulp 2 production scenarios and serves to address key concerns that could not be resolved within the existing Pulp 2 architecture.
+
+Pulp 3 reduces the challenges and dependencies that users experienced with Pulp 2. Built on Django, and using open standards such as OpenAPI, Pulp 3 has increased reliability and flexibility while reducing the code base. Plug-in writing has become easier thanks to the improved Plug-in API. Performance speeds, data integrity, and safety features, such as roll back to specific versions, have guided the development of Pulp 3.
+
+Pulp 3 and Pulp 2 have several conceptual differences. For more information about conceptual and terminology differences between Pulp 3 and Pulp 2, see [Renamed concepts](https://docs.pulpproject.org/from-pulp-2.html#renamed-concepts).
+
+## Pulp 3 vs Pulp 2 At A Glance
+
+Pulp 3 has the following advantages and features when compared to Pulp 2:
+
+* Improved performance and data integrity. Pulp 3 moves from MongoDB to PostgreSQL.
+* Faster performance. On testing, synchronizing in Pulp 3 ranges from two to eight times faster than Pulp 2.
+* Versioned repositories feature. New ability to rollback safely to earlier versions.
+* Disk storage and speed solutions. Select from [multiple synchronization](https://docs.pulpproject.org/workflows/on-demand-downloading.html) options for all content types to suit specific environmental requirements.
+* More storage options. Store content in the cloud with [storage services like S3 and Azure](https://docs.pulpproject.org/installation/storage.html).
+* Simplified installation. Ansible can automate Pulp 3 installation.
+* [Client bindings](https://docs.pulpproject.org/client_bindings.html) make Pulp’s API language agnostic, requiring no customization.
+* Browseable, auto-documented, OpenAPI.
+* Python’s PyPI replaces RPMs as the main packaging method, which allows for easy installation across Linux distributions.
+* Improvements to the Plug-in API ensures compatibility with Pulp core and has led to [an increasing list of Plug-ins](/pulp-3-plugins/).
+
+### Functionality that has been dropped or replaced entirely with Pulp 3
+
+System management features, which were present in Pulp 2, have been removed so that Pulp 3 maintains focus on providing the best and most stable repository management experience. Other tools, such as Ansible, can be used for system management. Some other services have been dropped as part of Pulp 3. For more information, see [Deprecating Consumers](/2018/03/01/deprecating-consumers/).
+
+* Pulp agent
+* Scheduled tasks
+* The entire Celery stack has been replaced by [RQ](/2018/05/08/pulp3-moving-to-rq/)
+* Pulp 2’s nodes concept has been removed in favor of Pulp server-to-server syncing
+
+### Functionality that does not currently exist but might be subject to change
+
+* Role-based access control is not available
+* No CLI
+* No Puppet or OSTree plug-ins are available
+
+
+## What do you think?
+
+Pulp 3 continues to provide the Pulp 2 core features while providing several key improvements along with an updated tech stack. If you have any questions or feedback, or would like to know more about the key changes, write to the [Pulp mailing list](https://www.redhat.com/mailman/listinfo/pulp-list) or join the conversation on [IRC](/help/#irc).

--- a/documentation.md
+++ b/documentation.md
@@ -1,5 +1,5 @@
 ---
-title: Documentation
+title: Versioned Documentation
 sidebar: home_sidebar
 permalink: /docs/
 toc: false

--- a/help.md
+++ b/help.md
@@ -15,6 +15,8 @@ Pulp is always fixing bugs, make sure you're running the latest version.
 
 Look in the docs for an answer at [docs.pulpproject.org](https://docs.pulpproject.org).
 
+For documentation on a specific version of Pulp, see [Versioned Documentation](/docs/).
+
 ## Issue Tracker
 
 Look to see if the current bug or feature exists on the [Pulp issues tracker](https://pulp.plan.io/issues?set_filter=1).


### PR DESCRIPTION
This PR aims to address the following feedback from the OSPO 2019 audit: 

"Add home page text about Pulp 2.0 vs. Pulp 3.0"

Because of the limited space on the navbar, I removed the "Documentation" page and added it as a link under "Help". I also renamed it to "Versioned Documentation" because the link doesn't provide the docs, just links to different versions of Pulp docs.

I would like to thank @ipanova and @bmbouter for helping me with this text and am very happy to change or edit any part of this. 

PS: Updating bundle locally updated the Bundle version in the `Gemfile.lock`. Did not seem to cause any problems. Everything built well. 