### PR TITLE
Revert Gemlock BUNDLED WITH version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,4 +238,4 @@ DEPENDENCIES
   nokogiri
 
 BUNDLED WITH
-   2.1.2
+   1.16.1


### PR DESCRIPTION
As part of #256 my local build updated the BUNDLED WITH version of the Gemlock file. This did not cause problems locally but did when merged. 

Reverting this change. 