### PR TITLE
Add Features page and change to drop down menu

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -1,10 +1,17 @@
 ## Topnav single links
 ## if you want to list an external url, use external_url instead of url. the theme will apply a different link base.
+topnav_dropdowns1:
+- title: Topnav dropdowns1
+  folders1:
+    - title: Pulp 3
+      folderitems1:
+        - title: About Pulp 3
+          url: /about-pulp-3/
+        - title: Features
+          url: /features/
 topnav:
 - title: Topnav
   items:
-    - title: Home
-      url: /
     - title: Pulp 3 Plugins
       url: /pulp-3-plugins/
     - title: Demo
@@ -18,12 +25,6 @@ topnav:
 topnav_dropdowns:
 - title: Topnav dropdowns
   folders:
-    - title: Pulp 3
-      folderitems:
-        - title: About Pulp 3
-          url: /about-pulp-3/
-        - title: Features
-          url: /features/
     - title: Contributing
       folderitems:
         - title: Get Involved

--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -5,8 +5,6 @@ topnav:
   items:
     - title: Home
       url: /
-    - title: About Pulp 3
-      url: /about-pulp-3/
     - title: Pulp 3 Plugins
       url: /pulp-3-plugins/
     - title: Demo
@@ -20,6 +18,12 @@ topnav:
 topnav_dropdowns:
 - title: Topnav dropdowns
   folders:
+    - title: Pulp 3
+      folderitems:
+        - title: About Pulp 3
+          url: /about-pulp-3/
+        - title: Features
+          url: /features/
     - title: Contributing
       folderitems:
         - title: Get Involved

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -12,6 +12,24 @@
         </div>
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav navbar-right">
+              {% for entry in site.data.topnav.topnav_dropdowns1 %}
+              {% for folder in entry.folders1 %}
+              <li class="dropdown">
+                  <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ folder.title }}<b class="caret"></b></a>
+                  <ul class="dropdown-menu">
+                      {% for folderitem in folder.folderitems1 %}
+                      {% if folderitem.external_url %}
+                      <li><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
+                      {% elsif page.url contains folderitem.url %}
+                      <li class="dropdownActive"><a href="{{folderitem.url | prepend: site.baseurl}}">{{folderitem.title}}</a></li>
+                      {% else %}
+                      <li><a href="{{folderitem.url | prepend: site.baseurl}}">{{folderitem.title}}</a></li>
+                      {% endif %}
+                      {% endfor %}
+                  </ul>
+              </li>
+              {% endfor %}
+              {% endfor %}
                 <!-- entries without drop-downs appear here -->
                 {% for entry in site.data.topnav.topnav %}
                 {% for item in entry.items %}

--- a/pulp-3-features.md
+++ b/pulp-3-features.md
@@ -1,0 +1,26 @@
+---
+title: Features
+sidebar: home_sidebar
+permalink: /features/
+toc: false
+---
+
+### One tool for different content types
+
+With Pulp, you can fetch, upload, and distribute content from a wide variety of content types. Add the plugins for the different content you want to work with and use Pulp to manage them all.  
+
+### Safely roll back with repository versioning
+
+Every time you add or remove content, Pulp creates an immutable repository version so that you can roll back to earlier versions and guarantee the safety and stability of your operation. Pulp maintains a record of all changes to help with troubleshooting and monitoring.
+
+### Optimizing disk storage and speed during remote synchronization
+
+Download and store only what you need from remote repositories. You can select from three modes to optimize disk speed and storage when synchronizing. While the default download option downloads all content, you can enable either the on_demand or streamed option. The on_demand option saves disk space by downloading and saving only the content that clients request. With the streamed option, you can download on request without saving the content in Pulp. This is ideal for synching content that you might require in the moment but not for the long term, for example, synchronizing from a nightly repository no longer requires disk clean up at a later stage.
+
+### Multiple Storage options
+
+As well as local file storage, Pulp supports a range of cloud storage options, such as Amazon S3 and Azure, to ensure that you can scale to meet the demands of your deployment.
+
+### Enabling Ansible collaboration on premise
+
+Using the Pulp Ansible plugin, you can create an on-premise platform to manage and distribute a scalable blend of public and private Ansible roles and collections across your organization.

--- a/pulp-3-features.md
+++ b/pulp-3-features.md
@@ -7,20 +7,16 @@ toc: false
 
 ### One tool for different content types
 
-With Pulp, you can fetch, upload, and distribute content from a wide variety of content types. Add the plugins for the different content you want to work with and use Pulp to manage them all.  
+With Pulp, you can fetch, upload, and distribute content from a wide variety of [content types](/pulp-3-plugins/). Add the plugins for the different content you want to work with and use Pulp to manage them all.  
 
 ### Safely roll back with repository versioning
 
-Every time you add or remove content, Pulp creates an immutable repository version so that you can roll back to earlier versions and guarantee the safety and stability of your operation. Pulp maintains a record of all changes to help with troubleshooting and monitoring.
+Every time you add or remove content, Pulp creates an immutable repository version so that you can roll back to earlier versions and thereby guarantee the safety and stability of your operation.
 
 ### Optimizing disk storage and speed during remote synchronization
 
-Download and store only what you need from remote repositories. You can select from three modes to optimize disk speed and storage when synchronizing. While the default download option downloads all content, you can enable either the on_demand or streamed option. The on_demand option saves disk space by downloading and saving only the content that clients request. With the streamed option, you can download on request without saving the content in Pulp. This is ideal for synching content that you might require in the moment but not for the long term, for example, synchronizing from a nightly repository no longer requires disk clean up at a later stage.
+Download and store only what you need from remote repositories. You can select from three modes to optimize disk speed and storage when synchronizing. While the _default_ download option downloads all content, you can enable either the _on_demand_ or _streamed_ option. The _on_demand_ option saves disk space by downloading and saving only the content that clients request. With the _streamed_ option, you download also on client request without saving the content in Pulp. This is ideal for synchronizing content, for example, from a nightly repository and saves having to perform a disk clean up at a later stage.
 
-### Multiple Storage options
+### Multiple storage options
 
 As well as local file storage, Pulp supports a range of cloud storage options, such as Amazon S3 and Azure, to ensure that you can scale to meet the demands of your deployment.
-
-### Enabling Ansible collaboration on premise
-
-Using the Pulp Ansible plugin, you can create an on-premise platform to manage and distribute a scalable blend of public and private Ansible roles and collections across your organization.


### PR DESCRIPTION
I wrote a draft Features page, which I hoped to distribute to the pulp-dev list for feedback and further input. 

https://melcorr.github.io/pulpproject.org/

As part of this, I want to create a drop-down menu item titled Pulp 3 after Home
 
Within Pulp 3 I wanted to nest the About Pulp 3 page and also the new Features page. I planned to expand this with further content next week. 

@bmbouter helped me resolve the issue with adding a drop-down menu to the topnav. 

I removed the "Home" link from the navigation, largely because it annoyed me, as we have a home icon and the Pulp icon that brings the user to the home page. 

Thanks! 