### PR TITLE
s/pulp-dev/pulp-list

### DIFF
--- a/_posts/2020-06-15-pulp-2-enters-maintenance-mode.md
+++ b/_posts/2020-06-15-pulp-2-enters-maintenance-mode.md
@@ -27,4 +27,4 @@ If you want to extend the existing functionality, feel free to raise a [pull req
 
 To view current progress and outstanding issues, see the [Migration plugin tracker](https://pulp.plan.io/projects/migration).
 
-If you have any questions or feedback, write to the pulp-dev@redhat.com mailing list.
+If you have any questions or feedback, write to the pulp-list@redhat.com mailing list.


### PR DESCRIPTION
@bmbouter noted that the email we should ask users to write to is pulp-list@ rather than pulp-dev. 

Updating that. 