### PR TITLE
add 3.7 release announcement

### DIFF
--- a/_posts/2020-09-20-pulp-3.7.0-is-generally-available.md
+++ b/_posts/2020-09-20-pulp-3.7.0-is-generally-available.md
@@ -1,0 +1,45 @@
+---
+title: Pulp 3.7.0 is Generally Available!
+author: Melanie Corr
+tags:
+  - release
+---
+
+The Pulp team are pleased to announce the release of Pulp 3.7.0!
+
+
+## Export enhancements
+
+There have been a number of enhancements to the export process:
+
+* A progress report has been added to export tasks. [#6541](https://pulp.plan.io/issues/6541)
+
+* Improved handling of failed exports. Previously, when an export failed, the export's tarball was left on the filesystem. This has now been cleaned up so that nothing remains and there is a clean slate. [#7246](https://pulp.plan.io/issues/7246)
+
+* A table of contents information (`TOC_info`) file has been added to point to the location of the TOC file during the export process. [#7221](https://pulp.plan.io/issues/7221)
+
+## Managing checksums
+
+`ALLOWED_CONTENT_CHECKSUMS` have been introduced so that users can specify and limit unwanted checksums in their environment. Note that plugins might not yet support `ALLOWED_CONTENT_CHECKSUMS` and that users should check plugin's release notes/docs for support before setting `ALLOWED_CONTENT_CHECKSUMS`. [#5216](https://pulp.plan.io/issues/5216)
+
+## Enabling automatic file deletion for Filefield
+
+Pulp has added [django-cleanup](https://pypi.org/project/django-cleanup/) to automatically cleanup files for models with `FileFields`. This also applies to models in plugins. Plugin writers can decorate their models with `@cleanup.ignore` to disable this. [#7316](https://pulp.plan.io/issues/7316)
+
+## Managing the Installation of Optional Dependences
+
+To make it easier to install optional dependencies such as S3 and Promethious support, as well as some test dependencies, an [**extras_require**](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies) argument has been added. [#6844](https://pulp.plan.io/issues/6844)
+
+## REST API Bug Fixes
+
+For a full list of bug fixes, see the [bug fixes](https://docs.pulpproject.org/pulpcore/changes.html#bugfixes) section of the changelog.
+
+## Plugin API Documentation
+
+There have been a number of enhancements to the plugin API documentation:
+
+* An [example](https://docs.pulpproject.org/pulpcore/plugins/plugin-writer/concepts/index.html#validating-models) has been added to show how to use a serializer to create validated objects.
+* Information about [serializers and OpenAPI schema](https://docs.pulpproject.org/pulpcore/plugins/reference/how-plugins-work.html?highlight=urlfield#serializer-and-openapi-schema) and constraints in this area have been added.
+*  A [Plugin API stability and deprecation policy](https://docs.pulpproject.org/pulpcore/plugins/plugin-writer/concepts/index.html?highlight=plugin%20api%20stability%20deprecation%20policy#plugin-api-stability-and-deprecation-policy) has been added.
+* An [Overriding the Reverse Proxy Route Configuration](https://docs.pulpproject.org/pulpcore/plugins/plugin-writer/concepts/index.html#overriding-the-reverse-proxy-route-configuration) section has been added.
+* The [custom installation tasks](https://docs.pulpproject.org/pulpcore/plugins/plugin-writer/concepts/index.html#custom-installation-tasks) section has been updated to reflect that plugin writers can contribute their custom installation needs directly to the installer.


### PR DESCRIPTION
https://melcorr.github.io/pulpproject.org/2020/09/20/pulp-3.7.0-is-generally-available/