### PR TITLE
Fix relative paths in pulp-in-one container run command

### DIFF
--- a/pulp-in-one-container.md
+++ b/pulp-in-one-container.md
@@ -31,10 +31,10 @@ For systems with SELinux in enforcing mode, use the following command to start P
 $ podman run --detach \
              --publish 8080:80 \
              --name pulp \
-             --volume ./settings:/etc/pulp:Z \
-             --volume ./pulp_storage:/var/lib/pulp:Z \
-             --volume ./pgsql:/var/lib/pgsql:Z \
-             --volume ./containers:/var/lib/containers:Z \
+             --volume "$(pwd)/settings":/etc/pulp:Z \
+             --volume "$(pwd)/pulp_storage":/var/lib/pulp:Z \
+             --volume "$(pwd)/pgsql":/var/lib/pgsql:Z \
+             --volume "$(pwd)/containers":/var/lib/containers:Z \
              --device /dev/fuse \
              pulp/pulp
 ```
@@ -47,10 +47,10 @@ For systems without SELinux in enforcing mode, use the following command to star
 $ podman run --detach \
              --publish 8080:80 \
              --name pulp \
-             --volume ./settings:/etc/pulp \
-             --volume ./pulp_storage:/var/lib/pulp \
-             --volume ./pgsql:/var/lib/pgsql \
-             --volume ./containers:/var/lib/containers \
+             --volume "$(pwd)/settings":/etc/pulp \
+             --volume "$(pwd)/pulp_storage":/var/lib/pulp \
+             --volume "$(pwd)/pgsql":/var/lib/pgsql \
+             --volume "$(pwd)/containers":/var/lib/containers \
              --device /dev/fuse \
              pulp/pulp
 ```


### PR DESCRIPTION
This guide advises users that they can substitute docker for podman when
running our container but doing so errors:

docker: Error response from daemon: create ./settings: "./settings"
includes invalid characters for a local volume name, only
"[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host
directory, use absolute path.