### PR TITLE
Add info about cloud storage per plugin

### DIFF
--- a/content-plugins.md
+++ b/content-plugins.md
@@ -8,9 +8,8 @@ toc: true
 ## Content Plugins
 
 As part of the Pulp installation, you must add a content plugin for each content type that you want
-to manage.
-The following sections contain information about the available content plugins for both Pulp 2 and
-Pulp 3. If you do not find the plugin for the content type you want to manage, consider
+to manage. The following sections contain information about the available content plugins for both
+Pulp 2 and Pulp 3. If you do not find the plugin for the content type you want to manage, consider
 [writing a plugin](https://docs.pulpproject.org/plugins/plugin-writer/index.html).
 
 ## Plugin Changes between Pulp 2 and Pulp 3

--- a/content-plugins.md
+++ b/content-plugins.md
@@ -7,8 +7,8 @@ toc: true
 
 ## Content Plugins
 
-As part of the Pulp installation, you must add a content plugin for each content type that you want to
-manage.
+As part of the Pulp installation, you must add a content plugin for each content type that you want
+to manage.
 The following sections contain information about the available content plugins for both Pulp 2 and
 Pulp 3. If you do not find the plugin for the content type you want to manage, consider
 [writing a plugin](https://docs.pulpproject.org/plugins/plugin-writer/index.html).
@@ -19,9 +19,7 @@ Pulp 3. If you do not find the plugin for the content type you want to manage, c
 * The Docker plugin in Pulp 2 has been replaced by the Container plugin.
 * Currently, there are no Pulp 3 plugins for Puppet and OSTree content.
 
-## Pulp 3 Content Plugin Features
-
-### A note on Pulp 3 CLI Coverage
+## Pulp 3 CLI Coverage
 
 The [Pulp 3 CLI](https://github.com/pulp/pulp-cli) is a work in progress.
 The CLI is implemented by the plugin writers, so the workflows that are possible with the CLI vary
@@ -33,6 +31,17 @@ At the moment, these plugins have the following coverage:
 * **Ansible**: Sync workflow (role & collection)
 * **Container**: Sync workflow
 * **Python**: Sync workflow
+
+## Cloud Storage
+
+It is possible to configure Pulp to use
+[cloud storage](https://docs.pulpproject.org/pulpcore/installation/storage.html).
+However, plugins can introduce changes that are incompatible with, for example, S3 requirements.
+The Pulp Ansible, RPM, File, Debian, Python, and Container plugins are regularly tested to ensure they remain compatible but the
+level of coverage is lower for other plugins.
+
+## Pulp 3 Content Plugin Features
+
 
 ### RPM
 

--- a/content-plugins.md
+++ b/content-plugins.md
@@ -34,11 +34,11 @@ At the moment, these plugins have the following coverage:
 
 ## Cloud Storage
 
-It is possible to configure Pulp to use
-[cloud storage](https://docs.pulpproject.org/pulpcore/installation/storage.html).
-However, plugins can introduce changes that are incompatible with, for example, S3 requirements.
-The Pulp Ansible, RPM, File, Debian, Python, and Container plugins are regularly tested to ensure they remain compatible but the
-level of coverage is lower for other plugins.
+It is possible to configure Pulp to use [cloud
+storage](https://docs.pulpproject.org/pulpcore/installation/storage.html). However, plugins can 
+introduce changes that are incompatible with, for example, S3 requirements. The Pulp Ansible, RPM,
+File, Debian, Python, and Container plugins are regularly tested to ensure they remain compatible
+but the level of coverage is lower for other plugins.
 
 ## Pulp 3 Content Plugin Features
 


### PR DESCRIPTION
I am trying to set... expectations a bit? 

The motivation behind this is to try and express which plugins can be relied on not only to test but to test and keep cloud storage options working. 

@mdellweg has explained that it is tested in a wider range of plugins, but I want to list the plugins where any issues are reliably fixed. I suppose I am trying to express where the user might expect *some* degree of certainty. 

As part of #361 