### PR TITLE
embed Discourse commenting into Pulp blog

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,7 +28,18 @@ layout: default
         {{ content }}
     </div>
 
+    <div id='discourse-comments'></div>
 
+    <script type="text/javascript">
+      DiscourseEmbed = { discourseUrl: 'http://discourse.pulpproject.org/',
+                         discourseEmbedUrl: 'https://pulpproject.org{{ page.url }}' };
+
+      (function() {
+        var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+        d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+      })();
+    </script>
 
 </article>
 
@@ -39,7 +50,3 @@ layout: default
 {{site.data.alerts.hr_shaded}}
 
 {% include footer.html %}
-
-
-
-


### PR DESCRIPTION
I'm trying to set up an RSS feed of our blog into Discourse. 
We also have the option to allow commenting on our blog that will then appear both at the end of the blog and in our discourse. 
When I test locally, the div renders but the comment functionality doesn't work on preview. 
This is the same when previewing a Foreman blog. 