### PR TITLE
Add gh ribbon to the homepage

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,15 +6,9 @@ layout: default
    <h1 class="post-title-main">{% if page.homepage != true %} {{ page.title }} {% endif %}</h1>
 </div>
 
-<div id="wrap">
-  <div class="container">
-    <a href="https://github.com/pulp" target="_blank" id="fork-me" class='hidden-tablet hidden-phone'><img style="position: fixed;top: 0; right: 0; border: 0;z-index:999999;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a>
-    <div class="row">
-      <div class="col-md-3 hidden-xs hidden-sm">
-        <div id="toc" class="sidebar-nav-fixed pull-right" data-spy="affix" data-offset-top="60" data-offset-bottom="300">
-        </div>
-      </div>
-
+<a href="https://github.com/pulp" target="_blank" id="fork-me" class='hidden-tablet hidden-phone'>
+  <img style="position: fixed;top: 0; right: 0; border: 0;z-index:999999;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub">
+</a>
 {% if page.map == true %}
 
 <script>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,6 +6,16 @@ layout: default
    <h1 class="post-title-main">{% if page.homepage != true %} {{ page.title }} {% endif %}</h1>
 </div>
 
+<div id="wrap">
+	<div class="container">
+		<a href="https://github.com/pulp" target="_blank" id="fork-me" class='hidden-tablet hidden-phone'><img style="position: fixed;top: 0; right: 0; border: 0;z-index:999999;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a>
+		<div class="row">
+      <div class="col-md-3 hidden-xs hidden-sm">
+				<div id="toc" class="sidebar-nav-fixed pull-right" data-spy="affix" data-offset-top="60" data-offset-bottom="300">
+				</div>
+			</div>
+
+
 {% if page.map == true %}
 
 <script>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,14 +7,13 @@ layout: default
 </div>
 
 <div id="wrap">
-	<div class="container">
-		<a href="https://github.com/pulp" target="_blank" id="fork-me" class='hidden-tablet hidden-phone'><img style="position: fixed;top: 0; right: 0; border: 0;z-index:999999;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a>
-		<div class="row">
+  <div class="container">
+    <a href="https://github.com/pulp" target="_blank" id="fork-me" class='hidden-tablet hidden-phone'><img style="position: fixed;top: 0; right: 0; border: 0;z-index:999999;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a>
+    <div class="row">
       <div class="col-md-3 hidden-xs hidden-sm">
-				<div id="toc" class="sidebar-nav-fixed pull-right" data-spy="affix" data-offset-top="60" data-offset-bottom="300">
-				</div>
-			</div>
-
+        <div id="toc" class="sidebar-nav-fixed pull-right" data-spy="affix" data-offset-top="60" data-offset-bottom="300">
+        </div>
+      </div>
 
 {% if page.map == true %}
 

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -932,16 +932,6 @@ span.soft {
     padding:10px;
 }
 
-/* this part adds an icon after external links, using FontAwesome*/
-a[href^="http://"]:after, a[href^="https://"]:after {
-    content: "\f08e";
-    font-family: FontAwesome;
-    font-weight: normal;
-    font-style: normal;
-    display: inline-block;
-    text-decoration: none;
-    padding-left: 3px;
-}
 
 /* Strip the outbound icon when this class is present */
 a[href].noCrossRef::after,


### PR DESCRIPTION
I've a few local draft runs of trying to resolve #95 

Every option I try looks a bit suboptimal... 

EDIT: second commit removes the icon after the HTML links. So it looks good now, but I've to figure out how to do this just for the ribbon. The third commit from @mdellweg fixes up the div tags. I stole Foreman's one. It did the job better than internet examples. 

So, the question now is, whether we really need to have an icon to indicate external links. 
If we do, then I need to figure out how to overwrite the CCS. This is low priority, and I'll try next Friday.
If we don't, this PR is good to go. 

https://melcorr.github.io/pulpproject.org/

It's associated with every external link. If I could stop that, I would be finished I think. 
