### PR TITLE
Change fork-me ribbon to pure css

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,9 +6,9 @@ layout: default
    <h1 class="post-title-main">{% if page.homepage != true %} {{ page.title }} {% endif %}</h1>
 </div>
 
-<a href="https://github.com/pulp" target="_blank" id="fork-me" class='hidden-tablet hidden-phone'>
-  <img style="position: fixed;top: 0; right: 0; border: 0;z-index:999999;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub">
-</a>
+<span id="forkongithub"><a href="https://github.com/pulp">Fork me on GitHub</a></span>
+
+
 {% if page.map == true %}
 
 <script>

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -202,6 +202,69 @@ p.external a {
     display:inline;
 }
 
+#forkongithub a
+{
+  background:#36ad03;
+  color:#fff;
+  text-decoration:none;
+  font-family:arial,sans-serif;
+  text-align:center;
+  font-weight:bold;
+  padding:5px 40px;
+  font-size:1rem;
+  line-height:2rem;
+  position:relative;
+  transition:0.5s;
+}
+#forkongithub a:hover
+{
+  background:#ed8b00;
+  color:#fff;
+}
+#forkongithub a::before,
+#forkongithub a::after
+{
+  content:"";
+  width:100%;
+  display:block;
+  position:fixed;
+  top:0;
+  left:0;
+  height:1px;
+  background:#fff;
+}
+#forkongithub a::after
+{
+  bottom:1px;
+  top:auto;
+}
+@media screen and (min-width:800px)
+{
+#forkongithub
+  {
+    position:fixed;
+    display:block;
+    top:0;
+    right:0;
+    width:200px;
+    overflow:hidden;
+    height:200px;
+    z-index:9999;
+  }
+#forkongithub a
+{
+  width:250px;
+  position:fixed;
+  top:60px;right:-60px;
+  transform:rotate(45deg);
+  -webkit-transform:rotate(45deg);
+  -ms-transform:rotate(45deg);
+  -moz-transform:rotate(45deg);
+  -o-transform:rotate(45deg);
+  box-shadow:4px 4px 10px rgba(0,0,0,0.8);
+}
+}
+
 #definition-box-container div a.active {
     font-weight: bold;
 }


### PR DESCRIPTION
@goosemania noticed last week how our current "Fork me on Github" ribbon was not a ribbon but a box. This box obscures the menu box when viewed on mobile. 
I propose we replace this with a CSS ribbon that only occupies the precise pixels of the ribbon rather than a square of website space. 

This also disappears in mobile view. 

You can view here: https://melcorr.github.io/pulpproject.org/

This is how it now looks on a mobile: [firefox for Android](https://photos.app.goo.gl/zcQksk9NevZbz2xS8)