### PR TITLE
Update example pulp_installer example execution

### DIFF
--- a/ansible-installer.md
+++ b/ansible-installer.md
@@ -36,7 +36,7 @@ Some of the roles used in the playbook use root privileges on the managed node, 
 you must provide the password for the managed node user.
 
 ```
-ansible-playbook playbooks/example-use/playbook.yml -u <managed_node_username> --ask-become-pass
+ansible-playbook playbooks/example-use/playbook.yml -u <managed_node_username> --ask-become-pass -i <managed_node_hostname>,
 ```
 
 <script id="asciicast-335159" src="https://asciinema.org/a/335159.js" async data-autoplay="true" data-speed="2"></script>


### PR DESCRIPTION
This commit is meant to keep the consistency with pulp_installer doc.
We are adding the '-i <managed_node_hostname>' flag in the example execution
to let users aware that it is also possible to configure the list of hosts
during the playbook run.