### PR TITLE
Client tooling updates

### DIFF
--- a/content-plugins.md
+++ b/content-plugins.md
@@ -11,7 +11,7 @@ toc: true
 
 As part of the Pulp installation, you must add a content plugin for each content type that you want
 to manage. The following sections contain information about the available content plugins. If you do
-not find the plugin for the content type you want to manage, consider 
+not find the plugin for the content type you want to manage, consider
 [writing a plugin](https://docs.pulpproject.org/plugins/plugin-writer/index.html).
 
 ## Plugin Changes between Pulp 2 and Pulp 3
@@ -20,12 +20,12 @@ not find the plugin for the content type you want to manage, consider
 * The Docker plugin in Pulp 2 has been replaced by the Container plugin.
 * Currently, there is no Pulp 3 plugin for Puppet content.
 
-## Pulp 3 CLI Coverage
+## Pulp CLI
 
-The [Pulp 3 CLI](https://github.com/pulp/pulp-cli) is continuously being expanded.
-The CLI is implemented by the plugin writers, so the workflows that are possible with the CLI vary
-from plugin to plugin.
-Please check the CLI directly to see the current workflow coverage for the desired plugin.
+The [Pulp CLI](https://github.com/pulp/pulp-cli) is continuously being expanded, so the workflow
+coverage with the CLI vary from plugin to plugin.
+Also support for some of them is maintained in separate
+[Pulp CLI Plugins](https://docs.pulpproject.org/pulp_cli/#cli-plugins).
 
 ## Role Based Access Control Support
 
@@ -34,7 +34,7 @@ Please check whether the plugin of your interest has already added RBAC support.
 
 ## Cloud Storage
 
-It is possible to configure Pulp to use 
+It is possible to configure Pulp to use
 [cloud storage](https://docs.pulpproject.org/pulpcore/installation/storage.html). However, plugins
 can introduce changes that are incompatible with, for example, S3 requirements. A number of plugins
 are regularly tested to ensure they remain compatible but the level of coverage might not cover our
@@ -93,8 +93,7 @@ Quay.io, and any other that is Docker Registry HTTP API V2-compatible in mirror 
 * Store private Ansible roles on-premise.
 * Install roles from pulp_ansible using the ansible-galaxy CLI.
 * Version content and rollback if necessary.
-* Support for the new multi-role content type from Galaxy.
-
+* Support for the Collections from Galaxy.
 
 ### Debian
 
@@ -115,11 +114,11 @@ Quay.io, and any other that is Docker Registry HTTP API V2-compatible in mirror 
 * Import new OSTree commits to an existing Pulp repository.
 * Consume content imported to Pulp using the ostree utility.
 
-#### Maven
+### Maven
 
 * Use Pulp as a pull through cache for Maven content.
 
-#### Ruby Gem
+### Ruby Gem
 
 * Synchronize remote repository content and metadata locally.
 * Upload your own content.

--- a/pulp-3-cli.md
+++ b/pulp-3-cli.md
@@ -1,21 +1,22 @@
 ---
-title: Pulp 3 CLI
+title: Pulp CLI
 sidebar: home_sidebar
 permalink: /pulp-3-cli/
 toc: false
 ---
 
-After you install Pulp, you may want to install the Pulp 3 CLI by following the [Pulp 3 CLI Quickstart guide](https://docs.pulpproject.org/pulp_cli/quickstart.html).
+After you install Pulp, you may want to install the Pulp CLI by following the [Pulp CLI Installation guide](https://docs.pulpproject.org/pulp_cli/installation/).
+Some plugins come with their own [cli plugin](https://docs.pulpproject.org/pulp_cli/#cli-plugins).
 
-You can find some example commands in the Quickstart. You can also find Pulp 3 CLI example workflows in the corresponding plugin documentation, where CLI commands have been implemented.
+You can find Pulp CLI example workflows in the corresponding plugin documentation, where CLI commands have been implemented.
 
-For example, you can find Pulp 3 CLI commands for the following Pulp Python workflows in the Pulp Python docs:
+For example, you can find Pulp CLI commands for the following Pulp Python workflows in the Pulp Python docs:
 
 * [Creating a distribution](https://docs.pulpproject.org/pulp_python/workflows/pypi.html#create-a-distribution)
 * [Syncing a repository](https://docs.pulpproject.org/pulp_python/workflows/sync.html)
 * [Creating and uploading to a repository](https://docs.pulpproject.org/pulp_python/workflows/upload.html)
 * [Creating and hosting a publication](https://docs.pulpproject.org/pulp_python/workflows/publish.html)
 
-For a list of plugin coverage, see **a-note-on-pulp-3-cli-coverage** on the [content plugins](/content-plugins/) homepage.
+For an extended list of plugin coverage, see [supported workflows](https://docs.pulpproject.org/pulp_cli/supported_workflows/) homepage.
 
-If you have any feedback about the Pulp 3 CLI,  find any bugs or want to request a specific CLI feature, file [an issue](https://github.com/pulp/pulp-cli/issues).
+If you have any feedback about the Pulp CLI,  find any bugs or want to request a specific CLI feature, file [an issue](https://github.com/pulp/pulp-cli/issues).

--- a/pulp-squeezer.md
+++ b/pulp-squeezer.md
@@ -5,12 +5,9 @@ permalink: /pulp-squeezer/
 toc: false
 ---
 
-
 Pulp Squeezer, formerly known as Pulp Ansible Modules, is a collection of Ansible modules that you can use to manage Pulp.
 
-Previously, you could use Ansible modules only to manage File content in Pulp. With this release, you can fetch, upload, organize, and distribute File, Ansible, and Python content.
-
-Installing collections with `ansible-galaxy` is only supported in Ansible 2.9 and higher.
+You can fetch, upload, organize, and distribute File, Ansible, Python, Container, Debian and RPM content.
 
 Check out Pulp Squeezer on [Ansible Galaxy](https://galaxy.ansible.com/pulp/squeezer).
 
@@ -18,34 +15,4 @@ Check out Pulp Squeezer on [Ansible Galaxy](https://galaxy.ansible.com/pulp/sque
 
 ## Available modules
 
-For Ansible content:
-
-*  `ansible_distribution`
-*  `ansible_remote`
-*  `ansible_repository`
-*  `ansible_role`
-*  `ansible_sync`
-
-For File content:
-
-*  `file_content`
-*  `file_distribution`
-*  `file_publication`
-*  `file_remote`
-*  `file_repository`
-*  `file_sync`
-
-For Python content:
-
-*  `python_distribution`
-*  `python_publication`
-*  `python_remote`
-*  `python_repository`
-*  `python_sync`
-
-Pulp general:
-
-*  `artifact`
-*  `delete_orphans`
-*  `status`
-*  `task`
+The current list of available modules can be found at [Squeezer modules](https://galaxy.ansible.com/ui/repo/published/pulp/squeezer/content/?sort=-pulp_created&showing=module).


### PR DESCRIPTION
* Replaced a dead link.
* Replaced outdated lists with proper links.
* Rebranded "Pulp 3 CLI" to "Pulp CLI".

[noissue]