### PR TITLE
docs: add missing $ and " to command expansion

### DIFF
--- a/pulp-in-one-container.md
+++ b/pulp-in-one-container.md
@@ -20,10 +20,10 @@ CentOS/RHEL 7 and later
 
 ```
 $ mkdir settings pulp_storage pgsql containers
-$ echo "CONTENT_ORIGIN='http://$(hostname):8080'
-ANSIBLE_API_HOSTNAME='http://$(hostname):8080'
-ANSIBLE_CONTENT_HOSTNAME='http://$(hostname):8080/pulp/content'
-TOKEN_SERVER = "http://(hostname):8080/token/"
+$ echo "CONTENT_ORIGIN = 'http://$(hostname):8080'
+ANSIBLE_API_HOSTNAME = 'http://$(hostname):8080'
+ANSIBLE_CONTENT_HOSTNAME = 'http://$(hostname):8080/pulp/content'
+TOKEN_SERVER = 'http://$(hostname):8080/token/'
 TOKEN_SIGNATURE_ALGORITHM = 'ES256'
 PUBLIC_KEY_PATH = '/tmp/public_key.pem'
 PRIVATE_KEY_PATH = '/tmp/private_key.pem'


### PR DESCRIPTION
Was going through the example and noticed this error.